### PR TITLE
Allow external binding to selectedTab in FloatingTabScaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .swiftpm/xcode/xcuserdata/huipeng.xcuserdatad/xcschemes/xcschememanagement.plist
+*.xcuserdata
+*.xcuserstate
+.swiftpm/xcode

--- a/Sources/FloatingTabKit/FloatingTabScaffold.swift
+++ b/Sources/FloatingTabKit/FloatingTabScaffold.swift
@@ -9,20 +9,23 @@ public struct FloatingTabBuilder {
 
 public struct FloatingTabScaffold: View {
     private let tabs: [FloatingTab]
-    private let initialTab: Int
     private let background: AnyShapeStyle
     private let cornerRadius: CGFloat
     private let shadow: ShadowStyle
+    private let initialTab: Int
 
+    @Binding private var selectedTabExternal: Int
     @State private var selectedTab: Int
 
     public init(
+        selectedTab: Binding<Int>,
         initialTab: Int = 0,
         background: AnyShapeStyle = AnyShapeStyle(Color.white),
         cornerRadius: CGFloat = 22,
         shadow: ShadowStyle = .default,
         @FloatingTabBuilder content: () -> [FloatingTab]
     ) {
+        self._selectedTabExternal = selectedTab
         self.tabs = content()
         self.initialTab = initialTab
         self.background = background
@@ -42,7 +45,10 @@ public struct FloatingTabScaffold: View {
                         FloatingTabButton(
                             icon: tab.icon,
                             isSelected: selectedTab == index,
-                            action: { selectedTab = index }
+                            action: {
+                                selectedTab = index
+                                selectedTabExternal = index
+                            }
                         )
                     }
                 }
@@ -60,4 +66,3 @@ public struct FloatingTabScaffold: View {
         }
     }
 }
-


### PR DESCRIPTION
### Changes
This PR enhances the `FloatingTabScaffold` component by exposing its internal `selectedTab` state as a `@Binding`, allowing external views to observe and react to tab changes.

### Motivation
Previously, the selected tab was managed entirely within the `FloatingTabScaffold`, making it impossible to observe tab changes externally (e.g., for haptic feedback or analytics). This change allows developers to do things like:

```swift
@State private var selectedTab = 0

FloatingTabScaffold(selectedTab: $selectedTab) {
    FloatingTab("house") { HomeView() }
    FloatingTab("star") { FavoriteView() }
    FloatingTab("gearshape") { SettingsView() }
    FloatingTab("person.crop.circle") { ProfileView() }
}
.onChange(of: selectedTab) {
    triggerHapticFeedback() // Some custom vibration feedback function
}
```